### PR TITLE
keyword argument should be lowercase

### DIFF
--- a/apps/home_presence_app/home_presence_app.py
+++ b/apps/home_presence_app/home_presence_app.py
@@ -112,7 +112,7 @@ class HomePresenceApp(ad.ADBase):
             # no gateway sensors, do app has to run arrive and depart scans every 2 minutes
             self.adbase.log(
                 "No Gateway Sensors specified, Monitor-APP will run Arrive and Depart Scan every 2 minutes. Please specify Gateway Sensors for a better experience",
-                Level="WARNING",
+                level="WARNING",
             )
             self.adbase.run_every(self.run_arrive_scan, self.adbase.datetime() + timedelta(seconds=1), 60)
             self.adbase.run_every(self.run_depart_scan, self.adbase.datetime() + timedelta(seconds=2), 60)


### PR DESCRIPTION
currently I get an error like:

```2020-03-01 00:40:50.355958 WARNING home_presence_app: Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/appdaemon/app_management.py", line 145, in initialize_app
    await utils.run_in_executor(self, init)
  File "/usr/lib/python3.8/site-packages/appdaemon/utils.py", line 276, in run_in_executor
    response = future.result()
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/appdaemon/apps/home_presence_app/home_presence_app.py", line 113, in initialize
    self.adbase.log(
  File "/usr/lib/python3.8/site-packages/appdaemon/adapi.py", line 145, in log
    self._log(logger, msg, *args, **kwargs)
  File "/usr/lib/python3.8/site-packages/appdaemon/adapi.py", line 91, in _log
    logger.log(self._logging.log_levels[level], msg, *args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1500, in log
    self._log(level, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'Level'
```

Changing the casing solves the problem