### PR TITLE
Add client_topics to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Requirements
            client_host: Broker IP Address or DNS
            client_user: username
            client_password: password
+           client_topics:
+               - NONE
     ```
 - [Andrew's Monitor](https://github.com/andrewjfreyer/monitor) running on the network. 
     - Have at least a single main node, which runs as `monitor.sh -tdr -a -b` in a location that users stay more often in line with @andrewjfreyer example setup. If having more than 1 monitor, have the rest run as `monitor.sh -tad -a -b` so they only scan on trigger for both arrival and departure.

--- a/apps/home_presence_app/home_presence_app.py
+++ b/apps/home_presence_app/home_presence_app.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 import traceback
 
 
-__VERSION__ = "2.4.0"
+__VERSION__ = "2.4.1"
 
 # pylint: disable=attribute-defined-outside-init,unused-argument
 class HomePresenceApp(ad.ADBase):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Monitor-App",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "AppDaemon Monitor-App to control The Monitor Presence Detection system",
   "main": "home_presence_app.py",
   "repository": {


### PR DESCRIPTION
Newer versions of AD handle wildcard topics differently.  Using the default of '#' breaks the event callback wildcard.

fixes: #72